### PR TITLE
.pre-commit-config.yaml: default to python3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 ---
+default_language_version:
+    # force all unspecified python hooks to run python3
+    python: python3
+
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
By default 'python' is used, which may point to older version that just
returns deprecation error.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>